### PR TITLE
空行を追加

### DIFF
--- a/config/local_settings.txt
+++ b/config/local_settings.txt
@@ -10,3 +10,4 @@ DATABASES = {
 }
 
 DEBUG = True
+


### PR DESCRIPTION
初期構築手順で`python config/get_random_secret_key.py >> config/local_settings.py`をした際に、config/local_settings.py（config/local_settings.txt）に別の記述の行にシークレットキーが入ってしまうので、空行を追加した。